### PR TITLE
add filter to useQueue to prevent stale queues from being returned

### DIFF
--- a/src/util/queue/hooks.ts
+++ b/src/util/queue/hooks.ts
@@ -11,8 +11,13 @@ export function useQueue(id: string): [Queue | undefined, boolean] {
         const unsubscribe = onSnapshot(doc(db, "queues", id), (doc) => {
             if (doc.exists()) {
                 const data = doc.data();
-                const endTime = data.endTime as Timestamp;
-                setQueue({...data, id: id, endTime: endTime.toDate()} as Queue);
+                const endTime = (data.endTime as Timestamp).toDate();
+                const yesterday = new Date();
+                yesterday.setDate(yesterday.getDate() - 1);
+
+                if (endTime > yesterday) {
+                    setQueue({...data, id: id, endTime: endTime} as Queue);
+                }
             }
             setLoading(false);
         });


### PR DESCRIPTION
this change corresponds to the backend changes I made. a queue is considered state after its end time is more than 1 day in the past. 